### PR TITLE
i18n "audittrail" category configuration fixed.

### DIFF
--- a/AuditTrail.php
+++ b/AuditTrail.php
@@ -19,6 +19,8 @@ use yii\db\ActiveRecord;
  */
 class AuditTrail extends ActiveRecord
 {
+    private $_message_category = 'audittrail';
+    
 	/**
 	 * @return string the associated database table name
 	 */
@@ -31,17 +33,27 @@ class AuditTrail extends ActiveRecord
 		}
 	}
 
-        /**
-         * @return \yii\db\Connection the database connection used by this AR class.
-         */
-        public static function getDb() {
-            if (isset(Yii::$app->params['audittrail.db'])) {
-                return Yii::$app->get(Yii::$app->params['audittrail.db']);
-            } else  {
-                return parent::getDb();
-            }
-            // return Yii::$app->get('dbUser');
+    /**
+     * @return \yii\db\Connection the database connection used by this AR class.
+     */
+    public static function getDb() 
+    {
+        if (isset(Yii::$app->params['audittrail.db'])) {
+            return Yii::$app->get(Yii::$app->params['audittrail.db']);
+        } else  {
+            return parent::getDb();
         }
+        // return Yii::$app->get('dbUser');
+    }
+        
+    public function init()
+    {
+        parent::init();
+        
+        \Yii::$app->i18n->translations[$this->_message_category] = [
+            'class' => 'yii\i18n\PhpMessageSource',
+        ];
+    }
 	
 	/**
 	 * @return array customized attribute labels (name=>label)


### PR DESCRIPTION
There was an error with the previous change of category from "app" to "audittrail" because Yii2 does not autoload all files from any category passed to translate function. 

https://github.com/yiisoft/yii2/blob/master/docs/guide/tutorial-i18n.md#specifying-default-translation

So I added an attribute to handle the new category, and also a init() function to add the category in the Yii:$app->i18n configuration.

![workspace 1_005](https://cloud.githubusercontent.com/assets/2817597/7108672/4c5187ce-e153-11e4-989f-18260da75a35.png)
