### PR TITLE
Invalid namespace for Exception

### DIFF
--- a/LoggableBehavior.php
+++ b/LoggableBehavior.php
@@ -4,6 +4,7 @@ namespace sammaye\audittrail;
 use Yii;
 use yii\base\Behavior;
 use yii\db\ActiveRecord;
+use Exception;
 
 class LoggableBehavior extends Behavior
 {


### PR DESCRIPTION
Error occurs when you trying to run command script.

> 2015-05-24 10:46:43 [-][-][-][error][Command\Test] exception 'yii\base\UnknownPropertyException' with message 'Getting unknown property: yii\console\Application::user' in /var/www/app/vendor/yiisoft/yii2/base/Component.php:143
